### PR TITLE
Implement new() as an instance method, and fix POD encoding warning

### DIFF
--- a/in/lib/Digest/BLAKE2x.pm
+++ b/in/lib/Digest/BLAKE2x.pm
@@ -16,6 +16,10 @@ our @EXPORT_OK = qw(
 
 1;
 
+__END__
+
+=encoding UTF-8
+
 =head1 NAME
 
 Digest::BLAKE2x - Perl XS interface to the BLAKE2x algorithm
@@ -94,4 +98,5 @@ Copyright (C) Tasuku SUENAGA a.k.a. gunyarakun
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself.
+
 =cut

--- a/lib/Digest/BLAKE2.pm
+++ b/lib/Digest/BLAKE2.pm
@@ -6,6 +6,7 @@ use warnings;
 our $VERSION = '0.02';
 
 use parent qw/Exporter Digest::base/;
+use Scalar::Util qw/blessed/;
 
 use Digest::BLAKE2b
   qw/blake2b blake2b_hex blake2b_base64 blake2b_base64url blake2b_ascii85/;
@@ -27,6 +28,13 @@ our @EXPORT_OK = qw/
 
 sub new {
     my ($class, $algorithm) = @_;
+    # $instance->new( ... ) resets the state of the hash
+    # context as an instance method.  See perldoc Digest.
+    if (blessed($class)) {
+        my $self = $class;
+        $self->{instance}->new();
+        return $self;
+    }
     $algorithm ||= 'b';
     unless ($algorithm =~ /^(blake2|BLAKE2)?((b|s)p?)$/) {
         die 'Invalid algorithm.';

--- a/lib/Digest/BLAKE2.pm
+++ b/lib/Digest/BLAKE2.pm
@@ -46,7 +46,10 @@ sub new {
 
 sub clone {
     my $self = shift;
-    $self->{instance}->clone(@_);
+    my $class = ref($self);
+    bless +{
+        instance => $self->{instance}->clone(@_),
+    }, $class;
 }
 
 sub add {

--- a/lib/Digest/BLAKE2.pm
+++ b/lib/Digest/BLAKE2.pm
@@ -61,6 +61,10 @@ sub digest {
 
 1;
 
+__END__
+
+=encoding UTF-8
+
 =head1 NAME
 
 Digest::BLAKE2 - Perl XS interface to the BLAKE2 algorithms
@@ -160,4 +164,5 @@ Copyright (C) Tasuku SUENAGA a.k.a. gunyarakun
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself.
+
 =cut

--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -57,6 +57,12 @@ unless ($@) {
     };
 }
 
+# https://github.com/Perl/perl5/issues/16200#issuecomment-544092140
+sub starts_with {
+    my ($base, $prefix) = @_;
+    rindex($base, $prefix, 0) == 0;
+}
+
 for my $algorithm (keys %algorithm_results) {
     my %results;
     @results{@targets} = @{ $algorithm_results{$algorithm} };
@@ -114,6 +120,29 @@ for my $algorithm (keys %algorithm_results) {
                 my $expect = pack('H*', $expected_hex);
                 is($digest, $expect, "$algorithm, instance new()");
             }
+        }
+
+        # Repeat the same for clone().  We exploit the fact
+        # that the first string is a prefix of the second.
+        {
+            my ($short_str, $long_str) = @targets;
+            starts_with($long_str, $short_str) or die "Assertion failed";
+
+            my $instance = $module_name->new;
+            $instance->add($short_str);
+            my $instcopy = $instance->clone;
+            $instcopy->add(substr($long_str, length $short_str));
+
+            # Postpone inspection of the $short_digest so
+            # the side effects of clone() would be visible
+            my $short_digest = $instance->digest;
+            my $long_digest = $instcopy->digest;
+
+            my $short_expect = pack('H*', $results{$short_str});
+            my $long_expect = pack('H*', $results{$long_str});
+
+            is($short_digest, $short_expect, "$algorithm, cloned instance");
+            is($long_digest, $long_expect, "$algorithm, clone instance");
         }
     };
 } ## end for my $algorithm (keys %algorithm_results)

--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -98,6 +98,23 @@ for my $algorithm (keys %algorithm_results) {
             $instance->add($target);
             is($instance->digest, pack('H*', $expected_hex));
         }
+
+        # The following test is the same, except we test
+        # the instance method to see the previous state has
+        # been properly cleared and does not affects the hash.
+        {
+            my $persistent_instance = $module_name->new;
+            $persistent_instance->add("JUNK");
+            for my $target (keys %results) {
+                my $expected_hex = $results{$target};
+
+                $persistent_instance = $persistent_instance->new;
+                $persistent_instance->add($target);
+                my $digest = $persistent_instance->digest;
+                my $expect = pack('H*', $expected_hex);
+                is($digest, $expect, "$algorithm, instance new()");
+            }
+        }
     };
 } ## end for my $algorithm (keys %algorithm_results)
 


### PR DESCRIPTION
According to [perldoc Digest](https://perldoc.perl.org/Digest#OO-INTERFACE):

> If new() is called as an **instance method** (i.e. `$ctx->new`) it will just reset the state the object to the state of a newly created object. No new object is created in this case, and the return value is the reference to the object (i.e. `$ctx`)

([`$ctx->reset`](https://perldoc.perl.org/Digest#$ctx-%3Ereset) also relies on this to work.)

I noticed that Digest::BLAKE2b and Digest::BLAKE2s seem to handle this correctly (though I can't be sure since I'm unfamiliar with XS code...) so all I did was tell Digest::BLAKE2 to delegate that to them.

There is also a second commit that silences pod2man's encoding warning (which is visible on MetaCPAN for both versions of Digest::BLAKE2.)

Also, I believe MetaCPAN lets you add a link to the source code repository... I think it'd be helpful to add a link to GitHub so people can find out where to submit patches. :)